### PR TITLE
feat(secret): add support for update 

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -7,3 +7,4 @@ on:
 jobs:
   integration:
     uses: ./.github/workflows/ansible-test-integration.yml
+    secrets: inherit

--- a/plugins/module_utils/model.py
+++ b/plugins/module_utils/model.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from dataclasses import dataclass, asdict
+
+
+def model_diff(source: dataclass, destination: dataclass) -> dict:
+    """
+    diff two models guaranteed to be the same type
+    the source model is the source of truth
+
+    example:
+        source:
+            Secret(
+                key1="value1",
+                key2="value2",
+            )
+        destination:
+            Secret(
+                key1="value1",
+                key2="value2",
+            )
+        return:
+            {}
+
+        source:
+            Secret(
+                key1="value1",
+                key2="value2",
+            )
+        destination:
+            Secret(
+                key1="value2",
+                key2="value3",
+            )
+        return:
+            {
+                "key1": "value1",
+                "key2": "value2",
+            }
+    """
+    if source.__class__.__name__ != destination.__class__.__name__:
+        raise ValueError(
+            f"The models are not the same: {source.__class__.__name__} != {destination.__class__.__name__}"
+        )
+
+    diff = {}
+
+    source_as_dict = asdict(source)
+    destination_as_dict = asdict(destination)
+
+    for key, value in source_as_dict.items():
+        if destination_as_dict[key] != value:
+            diff[key] = value
+
+    return diff

--- a/plugins/module_utils/scaleway_secret.py
+++ b/plugins/module_utils/scaleway_secret.py
@@ -1,25 +1,117 @@
 from __future__ import absolute_import, division, print_function
 
+from dataclasses import dataclass, field
+
+from .model import model_diff
+
 try:
     from scaleway.secret.v1beta1.api import SecretV1Beta1API
+    from scaleway import ScalewayException
 except ImportError:
     HAS_SCALEWAY_SDK = False
 
 __metaclass__ = type
 
 
-def get_secret_id(api: "SecretV1Beta1API", params: dict) -> str:
+class SecretNotFound(Exception):
+    pass
+
+
+@dataclass
+class Secret:
     """
-    Get a secret id from a secret name or directly from the params dict
-    Remove the secret_name from the params dict if any
+    Model a Secret object with fields we support mutability for
+    Excepted id and name which act as primary keys
     """
-    secret_name = params.pop("secret_name", None)
 
-    if params.get("secret_id") is None:
-        secret = api.list_secrets(name=secret_name, scheduled_for_deletion=False)
-        if len(secret.secrets) == 0:
-            raise Exception(f"Secret with name {secret_name} was not found")
+    name: str
+    id: str = ""
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
 
-        return secret.secrets[0].id
 
-    return params.get("secret_id")
+def build_secret(parameters: dict) -> Secret:
+    secret = Secret(name=parameters.get("name"))
+
+    for k, v in parameters.items():
+        if k in Secret.__dataclass_fields__:
+            setattr(secret, k, v)
+
+    return secret
+
+
+def get_secret(api: "SecretV1Beta1API", **kwargs) -> Secret:
+    """
+    Get a secret by secret_id or name
+    """
+    if "secret_id" in kwargs:
+        secret = api.get_secret(secret_id=kwargs["secret_id"])
+
+    elif "name" in kwargs:
+        secrets = api.list_secrets(name=kwargs["name"], scheduled_for_deletion=False)
+
+        if len(secrets.secrets) == 0:
+            raise SecretNotFound(f"Secret {kwargs['name']} not found")
+
+        secret = secrets.secrets[0]
+
+    else:
+        raise SecretNotFound("No secret_id or name provided")
+
+    return build_secret(secret.__dict__)
+
+
+def update_secret(
+    api: "SecretV1Beta1API", parameters: dict, check_mode: bool = False
+) -> tuple[bool, Secret, Secret]:
+    """
+    Update a secret by checking the difference between the source and destination object
+
+    The source object is builded from the parameters and act as the source of truth
+    The destination object is the object retrieved from the API
+
+    If the diff is empty, return the destination object
+    If the diff is not empty, try to update the secret with the updated values and return the source object for ansible to display the diff
+
+    return changed, updated_model, current_model
+    """
+    destination_model = get_secret(api, name=parameters.get("name"))
+
+    # build and diff source model with the api one
+    source_model = build_secret(parameters)
+    source_model.id = destination_model.id
+
+    diff = model_diff(source_model, destination_model)
+    if len(diff) == 0:
+        return False, source_model, destination_model
+
+    if check_mode:
+        return False, source_model, destination_model
+
+    updated_secret = api.update_secret(secret_id=destination_model.id, **diff)
+
+    return True, build_secret(updated_secret.__dict__), destination_model
+
+
+def is_duplicate(scw_exception: "ScalewayException") -> bool:
+    """
+    Inspect the content of raw Scaleway API json response to determine if the error is due to a duplicate secret
+    """
+    if scw_exception.status_code == 400:
+        return (
+            scw_exception.response.json()["details"][0]["help_message"]
+            == "cannot have same secret name in same path"
+        )
+    return False
+
+
+def build_diff(before_model: Secret, after_args: dict) -> dict:
+    """
+    Build an Ansible diff dictionary from a before and after model
+    """
+    after = build_secret(after_args)
+    after.id = before_model.id
+    return dict(
+        before=before_model.__dict__,
+        after=after.__dict__,
+    )

--- a/requirements-scaleway.txt
+++ b/requirements-scaleway.txt
@@ -1,1 +1,1 @@
-scaleway>=0.9.0
+scaleway>=2.9.0

--- a/tests/integration/targets/scaleway_secret/tasks/main.yml
+++ b/tests/integration/targets/scaleway_secret/tasks/main.yml
@@ -1,46 +1,78 @@
 ---
-- name: Create Secret
+- name: Create a new secret
   scaleway.scaleway.scaleway_secret:
-    secret_name: "ansible-test-secret"
+    name: "ansible-test-secret"
   register: secret
 
-- name: Print secret
-  ansible.builtin.debug:
-    var: secret
+- name: Re create the secret - no update
+  scaleway.scaleway.scaleway_secret:
+    name: "ansible-test-secret"
+  register: secret
 
-- name: Create Secret Version
+- name: Assert no update
+  ansible.builtin.assert:
+    that:
+      - secret.changed == False
+      - secret.diff.before == secret.diff.after
+
+- name: Update secret
+  scaleway.scaleway.scaleway_secret:
+    name: "ansible-test-secret"
+    description: "updated description"
+  register: secret
+
+- name: Assert secret updated
+  ansible.builtin.assert:
+    that:
+      - secret.data.description == "updated description"
+      - secret.diff.before.description == ""
+      - secret.diff.after.description == "updated description"
+
+- name: Update secret in check mode
+  scaleway.scaleway.scaleway_secret:
+    name: "ansible-test-secret"
+    description: "updated description"
+    tags:
+      - "tag1"
+      - "tag2"
+  register: secret
+  check_mode: true
+
+- name: Assert secret is not updated
+  ansible.builtin.assert:
+    that:
+      - secret.changed == False
+      - secret.diff.before.tags == []
+      - secret.diff.after.tags == ["tag1", "tag2"]
+
+- name: Create a new secret version
   scaleway.scaleway.scaleway_secret_version:
     secret_id: "{{ secret.data.id }}"
     data: "confidential data"
   register: secret_version
 
-- name: Print secret_version
-  ansible.builtin.debug:
-    var: secret_version
-
-- name: Assert Secret Version
+- name: Assert secret version created
   ansible.builtin.assert:
     that:
       - secret_version.data.revision == 1
 
-- name: Delete Secret Version
+- name: Delete secret version
   scaleway.scaleway.scaleway_secret_version:
     secret_id: "{{ secret.data.id }}"
     revision: "{{ secret_version.data.revision }}"
     state: absent
 
-- name: Delete Secret By Name
+- name: Delete secret
   scaleway.scaleway.scaleway_secret:
-    secret_name: "ansible-test-secret"
+    name: "ansible-test-secret"
     state: absent
 
-- name: Create Secret again
+- name: Create secret in check mode
   scaleway.scaleway.scaleway_secret:
-    secret_name: "ansible-test-secret"
-    state: present
+    name: "ansible-test-secret"
+    description: "updated description"
+    tags:
+      - "tag1"
+      - "tag2"
   register: secret
-
-- name: Delete Secret By ID
-  scaleway.scaleway.scaleway_secret:
-    secret_id: "{{ secret.data.id }}"
-    state: absent
+  check_mode: true


### PR DESCRIPTION
Handle the state of secret, see integration tests for use cases

- create a new secret
- re create the same secret with identical parameters => return changed=False, no diff
- re create the same secret with different parameters => update the secret, return changed=True, return a diff
- re create the same secret with identical or different parameters in check mode => do not update, return changed=False, return the diff 


Remove the secret id argument because the name must be unique and this used only in the delete case