### PR TITLE
feat: add `:` to fobidden characters in tags

### DIFF
--- a/plugins/inventory/scaleway.py
+++ b/plugins/inventory/scaleway.py
@@ -247,6 +247,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         forbidden_characters = [
             "-",
             " ",
+            ":",
         ]
         for forbidden_character in forbidden_characters:
             tag = tag.strip().replace(forbidden_character, "_")


### PR DESCRIPTION
This allow tags using the form `foo:bar` to generate new group `foo_bar`