### PR TITLE
feat(secret): add support of secret path

### DIFF
--- a/plugins/module_utils/scaleway_secret.py
+++ b/plugins/module_utils/scaleway_secret.py
@@ -23,15 +23,22 @@ def build_secret_version(parameters: dict) -> SecretVersion:
 
 def get_secret(api: "SecretV1Beta1API", **kwargs) -> Secret:
     """
-    Get a secret by secret_id or name
+    Get a secret by secret_id or name with optional path.
     """
     if "secret_id" in kwargs:
         secret = api.get_secret(secret_id=kwargs["secret_id"])
 
     elif "name" in kwargs:
-        secrets = api.list_secrets(name=kwargs["name"], scheduled_for_deletion=False)
+        list_kwargs = dict(name=kwargs["name"], scheduled_for_deletion=False)
+        if "path" in kwargs:
+            list_kwargs["path"] = kwargs["path"]
+        secrets = api.list_secrets(**list_kwargs)
 
         if len(secrets.secrets) == 0:
+            if "path" in kwargs:
+                raise SecretNotFound(
+                    f"Secret {kwargs['name']} not found at path {kwargs['path']}"
+                )
             raise SecretNotFound(f"Secret {kwargs['name']} not found")
 
         secret = secrets.secrets[0]
@@ -72,7 +79,10 @@ def update_secret(
 
     return changed, local_model, remote_model
     """
-    remote_model = get_secret(api, name=parameters.get("name"))
+    lookup = {"name": parameters.get("name")}
+    if "path" in parameters:
+        lookup["path"] = parameters["path"]
+    remote_model = get_secret(api, **lookup)
 
     # build and diff source model with the api one
     local_model = build_secret(parameters)

--- a/plugins/modules/scaleway_secret.py
+++ b/plugins/modules/scaleway_secret.py
@@ -31,6 +31,10 @@ options:
         description: name
         type: str
         required: true
+    path:
+        description: path
+        type: str
+        required: true
     project_id:
         description: project_id
         type: str
@@ -203,6 +207,7 @@ def main() -> None:
         dict(
             state=dict(type="str", default="present", choices=["absent", "present"]),
             name=dict(type="str", required=True),
+            path=dict(type="str", required=False),
             project_id=dict(type="str", required=False),
             tags=dict(type="list", required=False, elements="str"),
             description=dict(type="str", required=False),

--- a/plugins/modules/scaleway_secret.py
+++ b/plugins/modules/scaleway_secret.py
@@ -34,7 +34,8 @@ options:
     path:
         description: path
         type: str
-        required: true
+        required: false
+        default: /
     project_id:
         description: project_id
         type: str
@@ -207,7 +208,7 @@ def main() -> None:
         dict(
             state=dict(type="str", default="present", choices=["absent", "present"]),
             name=dict(type="str", required=True),
-            path=dict(type="str", required=False),
+            path=dict(type="str", required=False, default="/"),
             project_id=dict(type="str", required=False),
             tags=dict(type="list", required=False, elements="str"),
             description=dict(type="str", required=False),


### PR DESCRIPTION
### Summary

Add parameter `path` on the module `scaleway_secret`, to create secret on a different path than `/`.